### PR TITLE
Add upperbounds on Images version

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
-Images 0.5
+Images 0.5.0 0.11.0
 Interpolations 0.3
 Colors 0.6


### PR DESCRIPTION
Images is about to require julia 0.6, and Pyramids has an upper bound of 0.6 on the julia version